### PR TITLE
fixBugViewScrollReactorOutput: Fixed

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/block/CNBlocks.java
+++ b/src/main/java/net/nuclearteam/createnuclear/block/CNBlocks.java
@@ -3,6 +3,7 @@ package net.nuclearteam.createnuclear.block;
 import com.simibubi.create.AllTags;
 import com.simibubi.create.content.decoration.encasing.EncasedCTBehaviour;
 import com.simibubi.create.content.kinetics.BlockStressDefaults;
+import com.simibubi.create.content.kinetics.waterwheel.WaterWheelBlock;
 import com.simibubi.create.foundation.data.AssetLookup;
 import com.simibubi.create.foundation.data.CreateRegistrate;
 import com.simibubi.create.foundation.data.SharedProperties;
@@ -257,7 +258,8 @@ public class CNBlocks {
                 .tag(AllTags.AllBlockTags.SAFE_NBT.tag, CNTag.BlockTags.NEEDS_DIAMOND_TOOL.tag)
                 .transform(pickaxeOnly())
                 .blockstate(new ReactorOutputGenerator()::generate)
-                .transform(BlockStressDefaults.setCapacity(10240))
+                .transform(BlockStressDefaults.setCapacity(10240.0))
+                .transform(BlockStressDefaults.setGeneratorSpeed(ReactorOutput::getSpeedRange))
                 .item()
                 .transform(customItemModel())
                 .register();

--- a/src/main/java/net/nuclearteam/createnuclear/multiblock/output/ReactorOutput.java
+++ b/src/main/java/net/nuclearteam/createnuclear/multiblock/output/ReactorOutput.java
@@ -4,6 +4,7 @@ import com.simibubi.create.content.equipment.wrench.IWrenchable;
 import com.simibubi.create.content.kinetics.base.DirectionalKineticBlock;
 
 import com.simibubi.create.foundation.block.IBE;
+import com.simibubi.create.foundation.utility.Couple;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.Axis;
@@ -134,5 +135,9 @@ public class ReactorOutput extends DirectionalKineticBlock implements IWrenchabl
 		}
         return null;
     }
+
+	public static Couple<Integer> getSpeedRange() {
+		return Couple.create(-1500000, 1500000);
+	}
 }
 

--- a/src/main/java/net/nuclearteam/createnuclear/multiblock/output/ReactorOutputEntity.java
+++ b/src/main/java/net/nuclearteam/createnuclear/multiblock/output/ReactorOutputEntity.java
@@ -43,11 +43,11 @@ public class ReactorOutputEntity extends GeneratingKineticBlockEntity {
 	@Override
 	public void addBehaviours(List<BlockEntityBehaviour> behaviours) {
 		super.addBehaviours(behaviours);
-		generatedSpeed = new KineticScrollValueBehaviour(Lang.translateDirect("kinetics.reactor_output.rotation_speed"), this, new ReactorOutputValue());
+		/*generatedSpeed = new KineticScrollValueBehaviour(Lang.translateDirect("kinetics.reactor_output.rotation_speed"), this, new ReactorOutputValue());
 		generatedSpeed.between(-1500000, 1500000);
 		generatedSpeed.setValue(speed);
 		generatedSpeed.withCallback(i -> this.updateGeneratedRotation());
-		behaviours.add(generatedSpeed);
+		behaviours.add(generatedSpeed);*/
 
 	}
 


### PR DESCRIPTION
This pull request includes several changes to the `createnuclear` module, focusing on adding new functionality, updating existing methods, and cleaning up code. The most important changes include adding a new import for `WaterWheelBlock`, updating the block stress capacity and generator speed, and introducing a method to get the speed range.

### New functionality:

* [`src/main/java/net/nuclearteam/createnuclear/multiblock/output/ReactorOutput.java`](diffhunk://#diff-9198aec7346b04141c3bace31727468e8f277991f7f2b4f237cfde7ce7d15655R138-R141): Added a new method `getSpeedRange` that returns a `Couple<Integer>` representing the speed range for the reactor output.

### Updates to existing methods:

* [`src/main/java/net/nuclearteam/createnuclear/block/CNBlocks.java`](diffhunk://#diff-8b164c35c217cd387fbf482b0c742de0ebcd20139a6331c8eeb7f06a1b8d62caL260-R262): Updated the `transform` method to set the block stress capacity with a double value and added a new transformation to set the generator speed using `ReactorOutput::getSpeedRange`.

### Code cleanup:

* [`src/main/java/net/nuclearteam/createnuclear/block/CNBlocks.java`](diffhunk://#diff-8b164c35c217cd387fbf482b0c742de0ebcd20139a6331c8eeb7f06a1b8d62caR6): Added an import for `WaterWheelBlock` to the list of imports.
* [`src/main/java/net/nuclearteam/createnuclear/multiblock/output/ReactorOutputEntity.java`](diffhunk://#diff-31a185ac9d077b5e225d5748eaef459f54a4af764338eae1c662a61bb7b5b08aL46-R50): Commented out the `generatedSpeed` behavior to temporarily disable it.

These changes aim to enhance the functionality and maintainability of the `createnuclear` module.