### PR TITLE
Add fluid interaction management and mixin for liquid blocks

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/CreateNuclear.java
+++ b/src/main/java/net/nuclearteam/createnuclear/CreateNuclear.java
@@ -63,6 +63,8 @@ public class CreateNuclear implements ModInitializer {
 		CNRecipeTypes.register();
 		CNPotions.registerPotionRecipes();
 
+		CNFluids.registerFluidInteractions();
+
 		CNFanProcessingTypes.register();
 		ServerTickEvents.START_WORLD_TICK.register(CNFluids::handleFluidEffect);
 

--- a/src/main/java/net/nuclearteam/createnuclear/fluid/CNFluids.java
+++ b/src/main/java/net/nuclearteam/createnuclear/fluid/CNFluids.java
@@ -1,17 +1,37 @@
 package net.nuclearteam.createnuclear.fluid;
 
+import com.simibubi.create.AllFluids;
+import com.simibubi.create.content.decoration.palettes.AllPaletteStoneTypes;
+import com.simibubi.create.foundation.fluid.FluidHelper;
+import com.simibubi.create.foundation.utility.Iterate;
 import com.tterrag.registrate.fabric.SimpleFlowableFluid;
 import com.tterrag.registrate.util.entry.FluidEntry;
+import io.github.fabricators_of_create.porting_lib.event.common.FluidPlaceBlockCallback;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidConstants;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributeHandler;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
 import net.nuclearteam.createnuclear.CreateNuclear;
+import net.nuclearteam.createnuclear.block.CNBlocks;
 import net.nuclearteam.createnuclear.effects.CNEffects;
 import net.nuclearteam.createnuclear.tags.CNTag;
+
+import net.nuclearteam.createnuclear.fluid.FluidInteractionManager.FluidInteractionRule;
 
 import javax.annotation.Nullable;
 
@@ -68,4 +88,31 @@ public class CNFluids {
         });
     }
 
+    public static void registerFluidInteractions() {
+        // Uranium + water interaction
+        FluidInteractionManager.addRule(
+            CNFluids.URANIUM.get(),
+            new FluidInteractionRule(
+                100,
+                fs -> fs.is(FluidTags.WATER),
+                true,
+                isSource -> Blocks.GOLD_BLOCK.defaultBlockState(),
+                ctx -> {},
+                false
+            )
+        );
+
+        // Uranium + lava interaction
+        FluidInteractionManager.addRule(
+            CNFluids.URANIUM.get(),
+            new FluidInteractionRule(
+                100,
+                fs -> fs.is(FluidTags.LAVA),
+                true,
+                isSource -> Blocks.EMERALD_BLOCK.defaultBlockState(),
+                ctx -> {},
+                false
+            )
+        );
+    }
 }

--- a/src/main/java/net/nuclearteam/createnuclear/fluid/FluidInteractionManager.java
+++ b/src/main/java/net/nuclearteam/createnuclear/fluid/FluidInteractionManager.java
@@ -1,0 +1,98 @@
+package net.nuclearteam.createnuclear.fluid;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.LiquidBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.FlowingFluid;
+import net.minecraft.world.level.material.FluidState;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Central manager for registering and applying fluid interaction rules.
+ */
+public class FluidInteractionManager {
+    /**
+     * Context passed to interaction callbacks, encapsulating
+     * world, position, source flag, and the fluid instance.
+     */
+    public record InteractionContext(LevelAccessor world, BlockPos pos, boolean isSource, FlowingFluid fluid) {}
+
+
+    /**
+     * Defines how a source fluid interacts with an adjacent target fluid.
+     *
+     * @param priority     evaluation order (lower values are processed first)
+     * @param checkFluid   predicate to test the adjacent FluidState (e.g., water or lava)
+     * @param resultState  function that returns the replacement BlockState
+     *                     based on whether the source block is a full source (true) or flowing (false)
+     * @param onInteract   callback to execute after the default fizz effect
+     *                     (for additional particles, sounds, etc.)
+     * @param returnValue  the boolean value to return from shouldSpreadLiquid
+     *                     (false to cancel vanilla propagation, true to allow it)
+     */
+    public record FluidInteractionRule(int priority, Predicate<FluidState> checkFluid, Boolean excludeSelf, Function<Boolean, BlockState> resultState,
+                                       Consumer<InteractionContext> onInteract, boolean returnValue) {}
+
+    /** Map of source fluid → list of interaction rules. */
+    private static final Map<FlowingFluid, List<FluidInteractionRule>> RULES = new HashMap<>();
+
+    /** Directions in which to check adjacent fluids. */
+    private static final ImmutableList<Direction> DIRS = LiquidBlock.POSSIBLE_FLOW_DIRECTIONS;
+
+    /**
+     * Registers a new interaction rule for the given source fluid.
+     */
+    public static void addRule(FlowingFluid source, FluidInteractionRule rule) {
+        RULES.computeIfAbsent(source, f -> new ArrayList<>()).add(rule);
+    }
+
+    /**
+     * Applies the first matching rule for the given source fluid at the position.
+     * Executes a default fizz(), then any custom onInteract(), and returns
+     * Optional.of(returnValue). If no rule matches, returns Optional.empty().
+     */
+    public static Optional<Boolean> applyRules(FlowingFluid fluid,
+                                               LevelAccessor world,
+                                               BlockPos pos) {
+        List<FluidInteractionRule> list = RULES.get(fluid);
+        if (list == null || list.isEmpty()) {
+            return Optional.empty();
+        }
+
+        boolean isSource = world.getFluidState(pos).isSource();
+        InteractionContext ctx = new InteractionContext(world, pos, isSource, fluid);
+
+        List<FluidInteractionRule> sorted = list.stream()
+                .sorted(Comparator.comparingInt(r -> r.priority))
+                .toList();
+
+        for (FluidInteractionRule rule : sorted) {
+            boolean adjacentMatch = DIRS.stream()
+                    .map(d -> world.getFluidState(pos.relative(d)))
+                    .anyMatch(fs -> rule.checkFluid().test(fs) && (!rule.excludeSelf() || !fs.getType().isSame(fluid)));;
+            if (!adjacentMatch) continue;
+
+            // replace block
+            if (world instanceof Level level) {
+                level.setBlockAndUpdate(pos, rule.resultState.apply(isSource));
+            }
+            // default fizz effect
+            world.levelEvent(1501, pos, 0);
+            // custom effects
+            rule.onInteract.accept(ctx);
+            // return configured value
+            return Optional.of(rule.returnValue);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/net/nuclearteam/createnuclear/mixin/CNLiquidBlockMixin.java
+++ b/src/main/java/net/nuclearteam/createnuclear/mixin/CNLiquidBlockMixin.java
@@ -1,0 +1,33 @@
+package net.nuclearteam.createnuclear.mixin;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.LiquidBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.FlowingFluid;
+import net.nuclearteam.createnuclear.CreateNuclear;
+import net.nuclearteam.createnuclear.fluid.FluidInteractionManager;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Optional;
+
+@Mixin(LiquidBlock.class)
+public abstract class CNLiquidBlockMixin {
+    @Shadow @Final protected FlowingFluid fluid;
+
+    @Inject(at = @At("HEAD"), method = "shouldSpreadLiquid", cancellable = true)
+    private void shouldSpreadLiquid(Level level, BlockPos pos, BlockState state, CallbackInfoReturnable<Boolean> cir) {
+        Optional<Boolean> result = FluidInteractionManager.applyRules(fluid, level, pos);
+
+        if (result.isPresent()) {
+            CreateNuclear.LOGGER.info("Fluid interaction at {} returned {}", pos, result.get());
+            cir.setReturnValue(result.get());
+            cir.cancel();
+        }
+    }
+}

--- a/src/main/resources/createnuclear.mixins.json
+++ b/src/main/resources/createnuclear.mixins.json
@@ -3,7 +3,8 @@
   "package": "net.nuclearteam.createnuclear.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "CNBaseFireBlockMixin"
+    "CNBaseFireBlockMixin",
+    "CNLiquidBlockMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
- Implement FluidInteractionManager to handle fluid interaction rules.
- Register interactions for uranium with water and lava.
- Create CNLiquidBlockMixin to apply fluid interaction rules during liquid spread.
- Update mixins configuration to include CNLiquidBlockMixin.