### PR TITLE
Refactor radiation effect damage handling and armor check logic

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/effects/RadiationEffect.java
+++ b/src/main/java/net/nuclearteam/createnuclear/effects/RadiationEffect.java
@@ -6,6 +6,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.item.ItemStack;
 import net.nuclearteam.createnuclear.CreateNuclear;
 import net.nuclearteam.createnuclear.item.armor.AntiRadiationArmorItem;
 import net.nuclearteam.createnuclear.tags.CNTag;
@@ -25,18 +26,24 @@ public class RadiationEffect extends MobEffect {
 
     @Override
     public void applyEffectTick(LivingEntity livingEntity, int amplifier) {
-        //If the player has the radiation effect and is wearing the anti-radiation armor, they will not take damage
-        livingEntity.getArmorSlots().forEach(e -> {
-            if (livingEntity.hasEffect(CNEffects.RADIATION.get()) && AntiRadiationArmorItem.Armor.isArmored(e)) {
-                livingEntity.hurt(livingEntity.damageSources().magic(), 0.0F);
-                this.removeAttributeModifiers(livingEntity, livingEntity.getAttributes(), 0);
+        if (livingEntity.getType().is(CNTag.EntityTypeTags.IRRADIATED_IMMUNE.tag)) {
+            livingEntity.removeEffect(this);
+            return;
+        }
+
+        boolean isWearingAntiRadiationArmor = false;
+        for (ItemStack armor : livingEntity.getArmorSlots()) {
+            if (AntiRadiationArmorItem.Armor.isArmored(armor)) {
+                isWearingAntiRadiationArmor = true;
+                break;
             }
-            else if (livingEntity.getType().is(CNTag.EntityTypeTags.IRRADIATED_IMMUNE.tag)) {
-                livingEntity.removeEffect(this);
-            }
-            else {
-                livingEntity.hurt(livingEntity.damageSources().magic(), 1 << amplifier);
-            }
-        });
+        }
+
+        if (isWearingAntiRadiationArmor) {
+            return;
+        }
+
+        int damage = 1 << amplifier;
+        livingEntity.hurt(livingEntity.damageSources().magic(), damage);
     }
 }


### PR DESCRIPTION
This pull request refactors the `RadiationEffect` class to improve the handling of radiation damage logic and simplify the code. The main changes include restructuring the logic for checking anti-radiation armor and irradiated immunity, as well as removing redundant code.

### Improvements to radiation damage logic:

* **Refactored armor check logic:** Introduced a `boolean` flag (`isWearingAntiRadiationArmor`) to simplify the check for whether the entity is wearing anti-radiation armor, replacing the previous `forEach` loop. This improves readability and ensures the logic exits early when armor is detected. (`src/main/java/net/nuclearteam/createnuclear/effects/RadiationEffect.java`, [src/main/java/net/nuclearteam/createnuclear/effects/RadiationEffect.javaL28-R47](diffhunk://#diff-809685f5a0e0711f8764a2e1cfdc9b29a8a7a1b14d26b2fcea0e23f573640141L28-R47))

* **Simplified irradiated immunity handling:** Moved the check for entities immune to radiation (`CNTag.EntityTypeTags.IRRADIATED_IMMUNE`) to the beginning of the method and added an early `return` to avoid unnecessary processing. (`src/main/java/net/nuclearteam/createnuclear/effects/RadiationEffect.java`, [src/main/java/net/nuclearteam/createnuclear/effects/RadiationEffect.javaL28-R47](diffhunk://#diff-809685f5a0e0711f8764a2e1cfdc9b29a8a7a1b14d26b2fcea0e23f573640141L28-R47))

### Code cleanup:

* **Removed redundant damage logic:** Eliminated unnecessary calls to `removeAttributeModifiers` and redundant checks for the radiation effect, as they were no longer needed with the updated logic. (`src/main/java/net/nuclearteam/createnuclear/effects/RadiationEffect.java`, [src/main/java/net/nuclearteam/createnuclear/effects/RadiationEffect.javaL28-R47](diffhunk://#diff-809685f5a0e0711f8764a2e1cfdc9b29a8a7a1b14d26b2fcea0e23f573640141L28-R47))

* **Added missing import:** Included the `ItemStack` import to support the updated logic for iterating over armor slots. (`src/main/java/net/nuclearteam/createnuclear/effects/RadiationEffect.java`, [src/main/java/net/nuclearteam/createnuclear/effects/RadiationEffect.javaR9](diffhunk://#diff-809685f5a0e0711f8764a2e1cfdc9b29a8a7a1b14d26b2fcea0e23f573640141R9))