### PR TITLE
Fix error reactor

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/multiblock/IHeat.java
+++ b/src/main/java/net/nuclearteam/createnuclear/multiblock/IHeat.java
@@ -55,7 +55,7 @@ public interface IHeat extends IWrenchable {
         }
 
         public static HeatLevel of(int heat) {
-            return ofTest3(heat);
+            return ofInit(heat);
         }
 
         public static HeatLevel ofInit(int heat) {

--- a/src/main/java/net/nuclearteam/createnuclear/multiblock/controller/ReactorControllerBlock.java
+++ b/src/main/java/net/nuclearteam/createnuclear/multiblock/controller/ReactorControllerBlock.java
@@ -95,7 +95,7 @@ public class ReactorControllerBlock extends HorizontalDirectionalReactorBlock im
                 be.rotate(be.getBlockState(), be.getBlockPos().below(3), world, 0);
                 be.notifyUpdate();
             });
-            world.setBlock(pos, state.setValue(ASSEMBLED, false), 3);
+            //world.setBlock(pos, state.setValue(ASSEMBLED, false), 3);
             return InteractionResult.SUCCESS;
         }
 

--- a/src/main/java/net/nuclearteam/createnuclear/multiblock/controller/ReactorControllerBlockEntity.java
+++ b/src/main/java/net/nuclearteam/createnuclear/multiblock/controller/ReactorControllerBlockEntity.java
@@ -66,7 +66,7 @@ public class ReactorControllerBlockEntity extends SmartBlockEntity implements II
     public int baseUraniumHeat = CNConfigs.common().rods.baseValueUranium.get();
     public int baseGraphiteHeat = CNConfigs.common().rods.baseValueGraphite.get();
     public int proximityUraniumHeat = CNConfigs.common().rods.BoProxyUranium.get();
-    public int proximityGraphiteHeat = -CNConfigs.common().rods.MaProxigraphite.get();
+    public int proximityGraphiteHeat = CNConfigs.common().rods.MaProxigraphite.get();
     public int maxUraniumPerGraphite = CNConfigs.common().rods.uraMaxGraph.get();
     public int graphiteTimer = CNConfigs.common().rods.graphiteRodLifetime.get();
     public int uraniumTimer = CNConfigs.common().rods.uraniumRodLifetime.get();


### PR DESCRIPTION
This pull request introduces changes to improve heat calculation logic, adjust block state updates, and fix a configuration value in the nuclear reactor system. Below are the most important changes categorized by theme:

### Heat Calculation Logic:
* Updated the `HeatLevel` determination method in `IHeat.java` to use `ofInit` instead of `ofTest3`, likely to align with a more appropriate or updated implementation. (`src/main/java/net/nuclearteam/createnuclear/multiblock/IHeat.java`, [src/main/java/net/nuclearteam/createnuclear/multiblock/IHeat.javaL58-R58](diffhunk://#diff-abd079f5ff0f6b5d1a793514ebccafa0c23b0b2b48486dd41307c06a484e57c0L58-R58))

### Block State Updates:
* Commented out the line that resets the `ASSEMBLED` block state to `false` in `ReactorControllerBlock.java`, potentially to prevent unintended state changes during interaction. (`src/main/java/net/nuclearteam/createnuclear/multiblock/controller/ReactorControllerBlock.java`, [src/main/java/net/nuclearteam/createnuclear/multiblock/controller/ReactorControllerBlock.javaL98-R98](diffhunk://#diff-d1dbdbf65db3dc365857fa7c27dc824964178a46ad98cf76c0e49aa8cbe836a7L98-R98))

### Configuration Fix:
* Fixed the initialization of `proximityGraphiteHeat` in `ReactorControllerBlockEntity.java` by removing the negative sign, ensuring the value is correctly retrieved from the configuration. (`src/main/java/net/nuclearteam/createnuclear/multiblock/controller/ReactorControllerBlockEntity.java`, [src/main/java/net/nuclearteam/createnuclear/multiblock/controller/ReactorControllerBlockEntity.javaL69-R69](diffhunk://#diff-f76f5a0e807775ae35e528badc14c3bd1ebeee76038bf839a6510b0bc5ab2a9fL69-R69))