### PR TITLE
Refactor Reactor input validation to use CNTag for item matching

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/multiblock/controller/ReactorControllerBlockEntity.java
+++ b/src/main/java/net/nuclearteam/createnuclear/multiblock/controller/ReactorControllerBlockEntity.java
@@ -34,6 +34,7 @@ import net.nuclearteam.createnuclear.multiblock.IHeat;
 import net.nuclearteam.createnuclear.multiblock.output.ReactorOutput;
 import net.nuclearteam.createnuclear.multiblock.output.ReactorOutputEntity;
 import net.nuclearteam.createnuclear.multiblock.input.ReactorInputEntity;
+import net.nuclearteam.createnuclear.tags.CNTag;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -289,10 +290,10 @@ public class ReactorControllerBlockEntity extends SmartBlockEntity implements II
         String currentRod = "";
         ListTag list = inventory.getStackInSlot(0).getOrCreateTag().getCompound("pattern").getList("Items", Tag.TAG_COMPOUND);
         for (int i = 0; i < list.size(); i++) {
-            if (list.getCompound(i).getString("id").equals("createnuclear:uranium_rod")) {
+            if (ItemStack.of(list.getCompound(i)).is(CNTag.ItemTags.FUEL.tag)) {
                 heat += baseUraniumHeat;
                 currentRod = "u";
-            } else if (list.getCompound(i).getString("id").equals("createnuclear:graphite_rod")) {
+            } else if (ItemStack.of(list.getCompound(i)).is(CNTag.ItemTags.COOLER.tag)) {
                 heat += baseGraphiteHeat;
                 currentRod = "g";
             }
@@ -320,10 +321,10 @@ public class ReactorControllerBlockEntity extends SmartBlockEntity implements II
                             if (list.getCompound(l).getInt("Slot") == neighborSlot) {
                                 // If currentRod equals "u", apply the corresponding heat
                                 if (currentRod.equals("u")) {
-                                    String id = list.getCompound(l).getString("id");
-                                    if (id.equals("createnuclear:uranium_rod")) {
+                                    ItemStack stack = ItemStack.of(list.getCompound(i));
+                                    if (stack.is(CNTag.ItemTags.FUEL.tag)) {
                                         heat += proximityUraniumHeat;
-                                    } else if (id.equals("createnuclear:graphite_rod")) {
+                                    } else if (stack.is(CNTag.ItemTags.COOLER.tag)) {
                                         heat += proximityGraphiteHeat;
                                     }
                                 }

--- a/src/main/java/net/nuclearteam/createnuclear/multiblock/input/ReactorInputInventory.java
+++ b/src/main/java/net/nuclearteam/createnuclear/multiblock/input/ReactorInputInventory.java
@@ -3,6 +3,7 @@ package net.nuclearteam.createnuclear.multiblock.input;
 import io.github.fabricators_of_create.porting_lib.transfer.item.ItemStackHandler;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.nuclearteam.createnuclear.item.CNItems;
+import net.nuclearteam.createnuclear.tags.CNTag;
 
 public class ReactorInputInventory extends ItemStackHandler {
     private final ReactorInputEntity be;
@@ -21,8 +22,8 @@ public class ReactorInputInventory extends ItemStackHandler {
     @Override
     public boolean isItemValid(int slot, ItemVariant resource, int count) {
         return switch (slot) {
-            case 0 -> CNItems.URANIUM_ROD.get() == resource.getItem();
-            case 1 -> CNItems.GRAPHITE_ROD.get() == resource.getItem();
+            case 0 -> CNTag.ItemTags.FUEL.matches(resource.getItem());
+            case 1 -> CNTag.ItemTags.COOLER.matches(resource.getItem());
             default -> !super.isItemValid(slot, resource, count);
         };
     }


### PR DESCRIPTION
This pull request refactors the handling of item identification in the reactor system by replacing hardcoded item checks with tag-based checks, improving flexibility and maintainability. The changes primarily affect the `ReactorControllerBlockEntity` and `ReactorInputInventory` classes.

### Refactoring for Tag-Based Item Checks:

* **`ReactorControllerBlockEntity` Updates:**
  - Replaced hardcoded item ID checks for uranium and graphite rods with tag-based checks using `CNTag.ItemTags.FUEL` and `CNTag.ItemTags.COOLER` in the `calculateHeat` method. This change ensures that the logic can dynamically adapt to additional items matching these tags. [[1]](diffhunk://#diff-f76f5a0e807775ae35e528badc14c3bd1ebeee76038bf839a6510b0bc5ab2a9fL292-R296) [[2]](diffhunk://#diff-f76f5a0e807775ae35e528badc14c3bd1ebeee76038bf839a6510b0bc5ab2a9fL323-R327)
  - Added an import for `CNTag` to support the new tag-based checks.

* **`ReactorInputInventory` Updates:**
  - Updated the `isItemValid` method to use `CNTag.ItemTags.FUEL` and `CNTag.ItemTags.COOLER` for validating items in specific slots, replacing direct comparisons with specific item instances. This makes the inventory validation more extensible.
  - Added an import for `CNTag` to facilitate the new tag-based validation.